### PR TITLE
Update quickstart wording to API token

### DIFF
--- a/src/quickstart.md
+++ b/src/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-In this guide we will take you through setting up your Oasis dev environment, testing a simple Rust service using cargo, testing the same service using a locally running blockchain, and finally testing it using our Devnet 2.0.
+In this guide we will take you through setting up your Oasis dev environment, testing a simple Rust service using cargo, testing the same service using a locally running blockchain, and finally testing it using Devnet 2.0, our decentralized server.
 
 ## Set Up the Oasis SDK
 
@@ -46,8 +46,8 @@ Now that the tests pass, it's time build the service for deployment and test it 
 
 ## Integration Test Using the Local Chain
 
-In this step we will use the Javascript based test in the test directory.
-This script uses [oasis.js](https://github.com/oasislabs/oasis.js) to interact with the local chain or Devnet 2.0.
+In this step we will use the JavaScript-based test in the test directory.
+This script uses [oasis.js](https://github.com/oasislabs/oasis.js) to interact with either the local chain or Devnet 2.0.
 
 1. `oasis build`
 2. `cd ../app`
@@ -74,13 +74,13 @@ Tests:       3 passed, 3 total
    _Note:_ If you are a first-time user, you may be prompted to generate an Oasis-managed wallet, which you should do.
    Your wallet is what serves as your identity and enables you to interact with Oasis services.
 2. Make sure you are in a secure location, and then *Click to reveal*.  
-   This will reveal your private key, which is used to control your wallet.
-   You must never lose your private key nor share it with anyone—unless, of course, you want to lose control of your wallet!
-3. Give your local toolchain access to your wallet by running
+   This will reveal your API token, which is used to control your wallet.
+   You must never lose your API token nor share it with anyone—unless, of course, you want to lose control of your wallet!
+3. Give your local toolchain access to your wallet by first running
    ```
    oasis config profile.default.credential -
    ```
-    and then pasting in your private key.
+    and then pasting in your API token.
 
 You can now deploy your service to Devnet 2.0, using `oasis deploy`.
 When you run that command, with any luck, you'll see something like the following:

--- a/src/quickstart.md
+++ b/src/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-In this guide we will take you through setting up your Oasis dev environment, testing a simple Rust service using cargo, testing the same service using a locally running blockchain, and finally testing it using Devnet 2.0, our decentralized server.
+In this guide we will take you through setting up your Oasis dev environment, testing a simple Rust service using cargo, testing the same service using a locally running blockchain, and finally testing it using our Devnet 2.0.
 
 ## Set Up the Oasis SDK
 
@@ -76,7 +76,7 @@ Tests:       3 passed, 3 total
 2. Make sure you are in a secure location, and then *Click to reveal*.  
    This will reveal your API token, which is used to control your wallet.
    You must never lose your API token nor share it with anyone—unless, of course, you want to lose control of your wallet!
-3. Give your local toolchain access to your wallet by first running
+3. Give your local toolchain access to your wallet by running
    ```
    oasis config profile.default.credential -
    ```


### PR DESCRIPTION
To reflect migration from using private key as credential to API token.