### PR TITLE
Updated Joining the Testnet Docs

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -92,6 +92,7 @@ module.exports = {
             collapsable: true,
             children: [
               ['/operators/maintenance/wiping-node-state', 'Wiping Node State'],
+              ['/operators/maintenance/checking-account-nonce', 'Checking your Account nonce'],
             ],
           },
         ],

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -87,6 +87,13 @@ module.exports = {
             'Node Hardware Recommendations',
           ],
           ['/operators/stake-management', 'Stake Management'],
+          {
+            title: "Maintenance Guides",
+            collapsable: true,
+            children: [
+              ['/operators/maintenance/wiping-node-state', 'Wiping Node State'],
+            ],
+          },
         ],
       },
       {

--- a/src/operators/current-testnet-parameters.md
+++ b/src/operators/current-testnet-parameters.md
@@ -4,21 +4,74 @@ This page is meant to be kept up to date with the information from the
 currently released Testnet. Use the information here to deploy or upgrade your
 node on the Testnet.
 
+::: tip NOTE
+Feel free to use a seed node other than the Oasis seed node
+:::
+
+::: tip NOTE
+As the release management of our open source repositories improves, we will
+refer to more human-friendly versions of Oasis Core (and related built
+artifacts) in this document as opposed to commit-shas.
+:::
+
 * [Genesis Document](https://github.com/oasislabs/public-testnet-artifacts/releases/download/2019-11-13/genesis.json)
   * sha1: `33ad8f6c545d0a62d636b2624511dadd9cf94b37`
   * sha256: `1b2ea443c4b4381d4a907553eab246091ffd94d604ef55e0b7d6695c5512933f`
 * Oasis Seed Node Address:
   * `D14B9192C94F437E9FA92A755D3CC0341F2E87CF@34.82.86.53:26656`
-::: tip NOTE
-Feel free to use other seed nodes.
-:::
-* [Oasis Core commit SHA](https://github.com/oasislabs/oasis-core/commit/1f6d2de0688998712cba3f642e68ae70075b4d93):
-  * `1f6d2de0688998712cba3f642e68ae70075b4d93`
-* [Docker container](https://hub.docker.com/layers/oasislabs/oasis-node/master-20191113164754/images/sha256-b0b79c9988cf38a3214d63008c4861048acd0c5ebbf5fc163e2c673b8ffc60b3):
-  * `oasislabs/oasis-node:master-20191113164754`
+* [oasis-core](https://github.com/oasislabs/oasis-core) commit (_This will be
+  improved when we have proper versioning_)
+  * Commit-Sha: `1f6d2de0688998712cba3f642e68ae70075b4d93`
+* [docker container](https://hub.docker.com/layers/oasislabs/oasis-node/master-20191113164754/images/sha256-b0b79c9988cf38a3214d63008c4861048acd0c5ebbf5fc163e2c673b8ffc60b3)
+    * `$ docker pull oasislabs/oasis-node:master-20191113164754`
 
-::: tip NOTE
-As the release management of our open source repositories improves, we will
-refer to more human-friendly versions of Oasis Core (and related built
-artifacts) in this document.
-:::
+## Deployment Change Log
+
+### 2019-11-26 (Latest)
+
+#### `/serverdir/node/config.yml` Changes
+
+##### Changed
+
+Format for seed nodes has changed. Previously it only accepted a string. Now it
+supports an array of strings.
+
+Old Version:
+
+```yaml
+tendermint:
+  # ... other config
+  seeds: "{{ seed_node_address }}"
+```
+
+New Version:
+
+```yaml
+tendermint:
+  # ... other config
+  seed:
+    - "{{ seed_node_address0 }}"
+    - "{{ seed_node_address1 }}"
+```
+
+##### Removed
+
+This temporary configuration on the initial deployment is no longer necessary.
+These lines have been removed.
+
+```yaml
+## THESE NEXT 3 LINES ARE TEMPORARY YOU SHOULD NOT EXPOSE THIS PORT IN ANY WAY
+grpc:
+  debug:
+    port: "42261"
+```
+
+#### Staking and Registration Changes
+
+The CLI for creating and submitting staking and registration transactions have
+changed. If you've already staked and registered your entity, then there's no
+need to make any changes.
+
+### 2019-11-13
+
+This is the initial deployment

--- a/src/operators/current-testnet-parameters.md
+++ b/src/operators/current-testnet-parameters.md
@@ -19,7 +19,7 @@ testnet.
 
 ### 2019-11-26 (Latest)
 
-#### `/serverdir/node/config.yml` Changes
+#### `/serverdir/etc/config.yml` Changes
 
 ##### Changed
 

--- a/src/operators/current-testnet-parameters.md
+++ b/src/operators/current-testnet-parameters.md
@@ -15,8 +15,8 @@ artifacts) in this document.
 :::
 
 * [Genesis Document](https://github.com/oasislabs/public-testnet-artifacts/releases/download/2019-11-26/genesis.json)
-    * sha1: `<< todo update >>`
-    * sha256: `<< todo update >>`
+    * sha1: `bed77f6433e607f7073a48dbf27f8cf5d9a8c2e1`
+    * sha256: `ee38b53a2e8acd785d279e4c8d3af38b832f120d9a85bf0173e94878f45bc718`
 * Oasis Seed Node Address:
   * `D14B9192C94F437E9FA92A755D3CC0341F2E87CF@34.82.86.53:26656`
 * [oasis-core](https://github.com/oasislabs/oasis-core) commit (_This will be

--- a/src/operators/current-testnet-parameters.md
+++ b/src/operators/current-testnet-parameters.md
@@ -4,6 +4,16 @@ This page is meant to be kept up to date with the information from the currently
 released testnet. Use the information here to deploy or upgrade your node on the
 testnet.
 
+::: tip NOTE
+Feel free to use other seed nodes than the one provided here.
+:::
+
+::: tip NOTE
+As the release management of our open source repositories improves, we will
+refer to more human-friendly versions of Oasis Core (and related built
+artifacts) in this document.
+:::
+
 * [Genesis Document](https://github.com/oasislabs/public-testnet-artifacts/releases/download/2019-11-26/genesis.json)
     * sha1: `<< todo update >>`
     * sha256: `<< todo update >>`

--- a/src/operators/current-testnet-parameters.md
+++ b/src/operators/current-testnet-parameters.md
@@ -1,29 +1,19 @@
 # Current Testnet Parameters
 
-This page is meant to be kept up to date with the information from the
-currently released Testnet. Use the information here to deploy or upgrade your
-node on the Testnet.
+This page is meant to be kept up to date with the information from the currently
+released testnet. Use the information here to deploy or upgrade your node on the
+testnet.
 
-::: tip NOTE
-Feel free to use a seed node other than the Oasis seed node
-:::
-
-::: tip NOTE
-As the release management of our open source repositories improves, we will
-refer to more human-friendly versions of Oasis Core (and related built
-artifacts) in this document as opposed to commit-shas.
-:::
-
-* [Genesis Document](https://github.com/oasislabs/public-testnet-artifacts/releases/download/2019-11-13/genesis.json)
-  * sha1: `33ad8f6c545d0a62d636b2624511dadd9cf94b37`
-  * sha256: `1b2ea443c4b4381d4a907553eab246091ffd94d604ef55e0b7d6695c5512933f`
+* [Genesis Document](https://github.com/oasislabs/public-testnet-artifacts/releases/download/2019-11-26/genesis.json)
+    * sha1: `<< todo update >>`
+    * sha256: `<< todo update >>`
 * Oasis Seed Node Address:
   * `D14B9192C94F437E9FA92A755D3CC0341F2E87CF@34.82.86.53:26656`
 * [oasis-core](https://github.com/oasislabs/oasis-core) commit (_This will be
   improved when we have proper versioning_)
-  * Commit-Sha: `1f6d2de0688998712cba3f642e68ae70075b4d93`
-* [docker container](https://hub.docker.com/layers/oasislabs/oasis-node/master-20191113164754/images/sha256-b0b79c9988cf38a3214d63008c4861048acd0c5ebbf5fc163e2c673b8ffc60b3)
-    * `$ docker pull oasislabs/oasis-node:master-20191113164754`
+  * Commit-Sha: `9d5e30082a5f3df065fc52a404e048decb9adac9`
+* [docker container](https://hub.docker.com/layers/oasislabs/oasis-node/master-20191125134702/images/sha256-4e35b3bb8d9116cfcd6ff7d4f3d84e0753f7f441b48dad6d2129eb32897a3f9b)
+    * `$ docker pull oasislabs/oasis-node:master-20191125134702`
 
 ## Deployment Change Log
 

--- a/src/operators/current-testnet-parameters.md
+++ b/src/operators/current-testnet-parameters.md
@@ -29,7 +29,7 @@ artifacts) in this document.
 
 ### 2019-11-26 (Latest)
 
-#### `/serverdir/etc/config.yml` Changes
+#### `/serverdir/etc/config.yml` Required Changes
 
 ##### Changed
 

--- a/src/operators/current-testnet-parameters.md
+++ b/src/operators/current-testnet-parameters.md
@@ -72,6 +72,13 @@ The CLI for creating and submitting staking and registration transactions have
 changed. If you've already staked and registered your entity, then there's no
 need to make any changes.
 
+#### Docker Support
+
+We no longer document using the docker container for setup or deployment as we
+now distribute `oasis-node` binaries. You may still use the docker container,
+and we will, for now, document the current docker image tag for a given
+deployment.
+
 ### 2019-11-13
 
 This is the initial deployment

--- a/src/operators/current-testnet-parameters.md
+++ b/src/operators/current-testnet-parameters.md
@@ -81,4 +81,4 @@ deployment.
 
 ### 2019-11-13
 
-This is the initial deployment
+This is the initial deployment.

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -468,7 +468,7 @@ $ oasis-node stake account gen_escrow \
     --entity $ENTITY_DIR_PATH \
     --stake.escrow.account $ACCOUNT_ID \
     --stake.amount 100000000000000000000 \
-    --stake.transaction.file $OUTPUT_TX_FILE_PATH \
+    --transaction.file $OUTPUT_TX_FILE_PATH \
     --transaction.fee.gas 1000 \
     --transaction.fee.amount 1 \
     --transaction.nonce 0

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -317,9 +317,11 @@ tendermint:
 #### Ensuring Proper Permissions
 
 Only the owner of the process that runs node should have access to the files in
-the directory. The `oasis-node` binary is built to ensure, that the files used
-by the node are as secure as possible.  We suggest running the following to
-remove all non-owner read/write/execute permissions:
+the directory. The `oasis-node` binary ensures that the files used by the node
+are as least privileged as possible so that you don't accidentally shoot
+yourself in the foot while operating a node. To ensure the proper permissions,
+we suggest running the following to remove all non-owner read/write/execute
+permissions:
 
 ```bash
 chmod -R g-r,g-w,g-x,o-r,o-w,o-x /serverdir

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -170,7 +170,7 @@ In the `/serverdir` directory we will create the following subdirectories:
 You can make this directory structure by calling the following command:
 
 ```bash
-$ mkdir -m700 -p /serverdir/{etc,node/entity}
+$ mkdir -m700 -p /serverdir/{etc,node,node/entity}
 ```
 
 #### Copying the Node Artifacts from `/localhostdir`
@@ -317,8 +317,9 @@ tendermint:
 #### Ensuring Proper Permissions
 
 Only the owner of the process that runs node should have access to the files in
-the directory. We suggest running the following to remove all non-owner
-read/write/execute permissions:
+the directory. The `oasis-node` binary is built to ensure, that the files used
+by the node are as secure as possible.  We suggest running the following to
+remove all non-owner read/write/execute permissions:
 
 ```bash
 chmod -R g-r,g-w,g-x,o-r,o-w,o-x /serverdir

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -201,7 +201,8 @@ following files from `/localhostdir/node` to `/serverdir/node` over a secure cha
 * `tls_identity_cert.pem`
 
 After copying, make sure that all of these files have `0600` permissions:
-```
+
+```bash
 chmod -R 600 /serverdir/node/*.pem
 ```
 
@@ -425,6 +426,13 @@ already been funded.
 
 ::: tip NOTE
 This won't be necessary if your Entity is in the genesis file.
+:::
+
+::: warning NOTE
+If you've submitted staking or registry transactions before, your nonce is
+likely different than the nonce used in the examples. If you're uncertain,
+please check your account nonce by using [this
+guide](./maintenance/checking-account-nonce.md)
 :::
 
 Once you have been funded, you can now complete the process of connecting your

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -7,8 +7,11 @@ assumption of knowledge on the use of basic command line tools.
 If you joined the Testnet prior to 11/26, use the following steps to upgrade:
 1. [Stop your node and wipe state (keep node identity)](./maintenance/wiping-node-state.md)
 
-1. [Download the current genesis file and `oasis-node`](./current-testnet-parameters.md)
-1. [Update your node config](#configuring-the-oasis-node)
+1. [Download the current genesis file and `oasis-node` to your
+   server](./current-testnet-parameters.md)
+1. See the [Deployment Change
+   Log](./current-testnet-parameters.md#2019-11-26-latest) for a list of
+   changes. _Please ensure that you update your node configuration._
 1. Start your node
 :::
 

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -507,7 +507,7 @@ before hand.
 ```bash
 $ oasis-node registry entity gen_register \
   --genesis.file $GENESIS_FILE_PATH \
-  --datadir $ENTITY_DIR_PATH \
+  --entity $ENTITY_DIR_PATH \
   --transaction.file $OUTPUT_REGISTER_TX_FILE_PATH \
   --transaction.fee.gas 1000 \
   --transaction.fee.amount 1 \

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -214,7 +214,7 @@ You should download the latest `genesis.json` file and copy it to
 #### Configuring the Oasis Node
 
 ::: warning NOTE
-If you deployed with us on 2019-11-13, the configuration has changed. Please
+If you deployed a node on the 2019-11-13 Public Testnet, the configuration has changed. Please
 update your configuration or your node will fail to connect.
 :::
 

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -324,7 +324,7 @@ we suggest running the following to remove all non-owner read/write/execute
 permissions:
 
 ```bash
-chmod -R g-r,g-w,g-x,o-r,o-w,o-x /serverdir
+chmod -R go-r,go-w,go-x /serverdir
 ```
 
 However just so it's clear, the following permissions are expected by the

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -483,7 +483,10 @@ value used to track the account balance is 1x10^-18 tokens.
 
 ### Generating Entity Registration Transaction
 
-After you submit your escrow account.
+After you submit your escrow account, you'll need to register your entity so
+that it your node register properly. You could do this process _after_ you
+submit the escrow transaction, however, to save steps we prepare everything
+before hand.
 
 ```bash
 $ oasis-node registry entity gen_register \

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -508,7 +508,7 @@ before hand.
 ```bash
 $ oasis-node registry entity gen_register \
   --datadir $ENTITY_DIR_PATH \
-  --entity.transaction.file $OUTPUT_REGISTER_TX_FILE_PATH
+  --transaction.file $OUTPUT_REGISTER_TX_FILE_PATH
 ```
 
 * `$ENTITY_DIR_PATH` - For this guide this would be `/localhostdir/entity/`

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -1,7 +1,7 @@
 # Joining the Testnet
 
 This guide will cover setting up your nodes on the Public Testnet. There is some
-assumption of knowledge on the use of basic command line tools and docker.
+assumption of knowledge on the use of basic command line tools.
 
 ::: tip NOTE
 If you joined the Testnet prior to 11/26, use the following steps to upgrade:
@@ -345,22 +345,6 @@ However just so it's clear, the following permissions are expected by the
 
 ### Starting the Oasis Node
 
-#### Starting with docker
-
-For those of you who are relying on the
-[oasis-node](https://hub.docker.com/r/oasislabs/oasis-node) docker container,
-the command to start the oasis-node is:
-
-```bash
-$ docker run --entrypoint /oasis/bin/oasis-node \
-    --name oasis_node \
-    --volume /serverdir:/serverdir \
-    --workdir /serverdir/node \
-    -p 26656:26656 \
-    oasislabs/oasis-node:$OASIS_NODE_TAG \
-    --config /serverdir/etc/config.yml
-```
-
 ::: danger WARNING
 In a previous version of docs we asked you to open `-p 42261:42261` port. This
 is no longer needed and should be removed immediately. Keeping that port open
@@ -368,21 +352,9 @@ was a temporary measure and is unsafe generally. Please close that port to the
 public and do not bind to it in any way.
 :::
 
-This will create a docker container named `oasis_node`. This is useful to have a
-named container so it can be referenced later. If you name it something else,
-then be aware that the docs will reference `oasis_node` for this docker
-container.
-
-_It is up to you to configure these options how you see fit. This invocation of
-the server process will not restart automatically. If you'd like to run this in
-the background add the docker flag `--detach`_
-
-#### Starting without docker
-
-If you have built the `oasis-node` binary on your own, you can start the server
-by running the command below. Please note, the node is, by default, configured
-to run in the foreground. You will need to use a process supervisor like
-[supervisord](http://supervisord.org/),
+You can start the server by running the command below. Please note, the node is
+configured to run in the foreground. We suggest you daemonize this with a
+process supervisor like [supervisord](http://supervisord.org/),
 [systemd](https://github.com/systemd/systemd), etc.
 
 ```bash
@@ -395,8 +367,7 @@ As part of the starting the server process, the `oasis-node` binary will, by
 default, setup an internal unix socket in the `datadir` of the Node. This socket
 can be used to communicate to the node and query details about the network.
 
-The following should be run from inside the docker container or the server,
-depending on how you chose to start the node.
+Run the following command:
 
 ```bash
 $ oasis-node registry entity list -a unix:/serverdir/node/internal.sock
@@ -550,20 +521,6 @@ transactions:
    `/serverdir/signed-register.tx` on the `server`.
 3. Call `oasis-node` like so:
 
-  If you're using docker use:
-
-  ```bash
-  $ docker exec -it oasis_node /bin/bash
-  $ oasis-node consensus submit_tx \
-    --transaction.file /serverdir/signed-escrow.tx \
-    -a unix:/serverdir/node/internal.sock
-  $ oasis-node consensus submit_tx \
-    --transaction.file /serverdir/signed-register.tx \
-    -a unix:/serverdir/node/internal.sock
-  ```
-
-  Without docker:
-
   ```bash
   $ oasis-node consensus submit_tx \
     --transaction.file /serverdir/signed-escrow.tx \
@@ -600,8 +557,7 @@ We will use `s+vZ71qeZnlq0HmQSDBiWn2OKcy3fXOuPMu76/5GkUI=`. As the key to search
 
 ### grepping for the Node's Identity
 
-Finally to see if the node is properly registered, run the command (you may need
-to be in a docker container if you are using that):
+Finally to see if the node is properly registered, run the command:
 
 ```bash
 $ export NODE_PUB_KEY="s+vZ71qeZnlq0HmQSDBiWn2OKcy3fXOuPMu76/5GkUI="

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -445,13 +445,22 @@ already been funded.
 This won't be necessary if your Entity is in the genesis file.
 :::
 
-::: warning CAUTION
-If your node is NOT caught up to the network you will most likely fail to submit
-these transactions.
-:::
-
 Once you have been funded, you can now complete the process of connecting your
 node by staking so that you can register your entity and register your node.
+
+### Check that your node is synced
+
+Before you can make any transactions you'll have to make sure that node is
+synced. To do so call this command on the server:
+
+```bash
+$ oasis-node control is-synced \
+  -a unix:/serverdir/node/internal.sock
+```
+
+If the command exits with a status code of `0` then you're fully synced and you
+can continue. If not, you will need to wait until it is before you can move
+forward.
 
 ### Generating a Staking (Escrow) Transaction on the `localhost`
 

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -500,7 +500,7 @@ value used to track the account balance is 1x10^-18 tokens.
 ### Generating Entity Registration Transaction
 
 After you submit your escrow account, you'll need to register your entity so
-that your node register properly. You could do this process _after_ you
+that your node registers properly. You could do this process _after_ you
 submit the escrow transaction, however, to save steps we prepare everything
 before hand.
 

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -184,7 +184,6 @@ following files from `/localhostdir/node` to `/serverdir/node` over a secure cha
 * `consensus_pub.pem`
 * `identity.pem`
 * `identity_pub.pem`
-* `node_genesis.json`
 * `p2p.pem`
 * `p2p_pub.pem`
 * `tls_identity.pem`

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -6,7 +6,6 @@ assumption of knowledge on the use of basic command line tools.
 ::: tip NOTE
 If you joined the Testnet prior to 11/26, use the following steps to upgrade:
 1. [Stop your node and wipe state (keep node identity)](./maintenance/wiping-node-state.md)
-
 1. [Download the current genesis file and `oasis-node` to your
    server](./current-testnet-parameters.md)
 1. See the [Deployment Change

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -9,7 +9,7 @@ If you joined the Testnet prior to 11/26, use the following steps to upgrade:
 
 1. [Download the current genesis file and `oasis-node`](./current-testnet-parameters.md)
 1. [Update your node config](#configuring-the-oasis-node)
-1. Restart your node
+1. Start your node
 :::
 
 ## Prerequisites

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -3,6 +3,14 @@
 This guide will cover setting up your nodes on the Public Testnet. There is some
 assumption of knowledge on the use of basic command line tools and docker.
 
+::: tip NOTE
+If you joined the Testnet prior to 11/26, use the following steps to upgrade:
+1. [Stop your node and wipe state](./maintenance/wiping-node-state.md)
+1. [Download the current genesis file and `oasis-node`](./current-testnet-parameters.md)
+1. [Update your node config](#configuring-the-oasis-node)
+1. Restart your node
+:::
+
 ## Prerequisites
 
 Before following this guide, make sure you've followed the [Prerequisites

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -580,7 +580,3 @@ If `grep` found the key, then you're properly connected!
 
 If you've made it this far you've properly connected your node to the network
 and you're now a Validator on the Public Testnet.
-
-### Maintenance Guides
-
-* [Wiping Node State](./maintenance/wiping-node-state.md)

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -513,7 +513,7 @@ $ oasis-node registry entity gen_register \
   --transaction.file $OUTPUT_REGISTER_TX_FILE_PATH \
   --transaction.fee.gas 1000 \
   --transaction.fee.amount 1 \
-  --transaction.nonce 0
+  --transaction.nonce 1
 ```
 
 * `$ENTITY_DIR_PATH` - For this guide this would be `/localhostdir/entity/`

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -316,7 +316,7 @@ tendermint:
     - "[[ seed_node_address ]]"
 ```
 
-#### Ensuring proper permissions
+#### Ensuring Proper Permissions
 
 Only the owner of the process that runs node should have access to the files in
 the directory. We suggest running the following to remove all non-owner

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -5,7 +5,8 @@ assumption of knowledge on the use of basic command line tools and docker.
 
 ::: tip NOTE
 If you joined the Testnet prior to 11/26, use the following steps to upgrade:
-1. [Stop your node and wipe state](./maintenance/wiping-node-state.md)
+1. [Stop your node and wipe state (keep node identity)](./maintenance/wiping-node-state.md)
+
 1. [Download the current genesis file and `oasis-node`](./current-testnet-parameters.md)
 1. [Update your node config](#configuring-the-oasis-node)
 1. Restart your node

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -214,8 +214,8 @@ You should download the latest `genesis.json` file and copy it to
 #### Configuring the Oasis Node
 
 ::: warning NOTE
-If you deployed a node on the 2019-11-13 Public Testnet, the configuration has changed. Please
-update your configuration or your node will fail to connect.
+If you deployed a node on the 2019-11-13 Public Testnet, the configuration has
+changed. Please update your configuration or your node will fail to connect.
 :::
 
 There are a variety of options available when running an Oasis node. The

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -353,8 +353,8 @@ $ docker run --entrypoint /oasis/bin/oasis-node \
 ::: danger WARNING
 In a previous version of docs we asked you to open `-p 42261:42261` port. This
 is no longer needed and should be removed immediately. Keeping that port open
-was a temporary measure and is unsafe generally. Please close that port and do
-not bind to it in any way.
+was a temporary measure and is unsafe generally. Please close that port to the
+public and do not bind to it in any way.
 :::
 
 This will create a docker container named `oasis_node`. This is useful to have a
@@ -469,9 +469,9 @@ $ oasis-node stake account gen_escrow \
     --stake.escrow.account $ACCOUNT_ID \
     --stake.transaction.amount 100000000000000000000 \
     --stake.transaction.file $OUTPUT_TX_FILE_PATH \
-    --stake.transaction.fee.gas 1000 \
-    --stake.transaction.fee.amount 1 \
-    --stake.transaction.nonce 0
+    --transaction.fee.gas 1000 \
+    --transaction.fee.amount 1 \
+    --transaction.nonce 0
 ```
 
 The parameters are as follows:
@@ -506,8 +506,12 @@ before hand.
 
 ```bash
 $ oasis-node registry entity gen_register \
+  --genesis.file $GENESIS_FILE_PATH \
   --datadir $ENTITY_DIR_PATH \
-  --transaction.file $OUTPUT_REGISTER_TX_FILE_PATH
+  --transaction.file $OUTPUT_REGISTER_TX_FILE_PATH \
+  --transaction.fee.gas 1000 \
+  --transaction.fee.amount 1 \
+  --transaction.nonce 0
 ```
 
 * `$ENTITY_DIR_PATH` - For this guide this would be `/localhostdir/entity/`

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -223,15 +223,14 @@ following YAML file is a basic configuration for a validator node on the
 network.
 
 Before using this configuration you should collect the following information to
-replace the `[[ var ]]` variables present in the configuration file:
+replace the variables present in the configuration file:
 
-* `[[ external_address ]]`: This is the external IP you wish to use when
+* `external_address`: This is the external IP you wish to use when
   registering this node. If you are using a Sentry Node, you should use the
   public IP of that machine.
 
-* `[[ seed_node_address ]]`:  This the seed node address in the form `[[ ID
-  ]]@[[ IP ]]:[[ PORT ]]` this is published
-  [here](./current-testnet-parameters.md)
+* `seed_node_address`:  This the seed node address in the form
+  `<id>@<host>:<port>` this is published [here](./current-testnet-parameters.md)
 
 Create a file, `/serverdir/etc/config.yml`, with the following
 contents:
@@ -313,7 +312,7 @@ tendermint:
   # You can add additional seeds to this list of seed addresses if you know of
   # additional seeds
   seed:
-    - "[[ seed_node_address ]]"
+    - "{{ seed_node_address }}"
 ```
 
 #### Ensuring Proper Permissions

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -521,7 +521,8 @@ $ oasis-node registry entity gen_register \
 
 ### Submitting Your Transactions on the `server`
 
-To complete the staking process we need to submit your escrow transaction:
+To complete the staking process we need to submit your escrow and registry
+transactions:
 
 1. Copy the file `/localhostdir/signed-escrow.tx` on the `localhost` to
    `/serverdir/signed-escrow.tx` on the `server`.
@@ -533,10 +534,10 @@ To complete the staking process we need to submit your escrow transaction:
 
   ```bash
   $ docker exec -it oasis_node /bin/bash
-  $ oasis-node stake account submit \
-    --stake.transaction.file /serverdir/signed-escrow.tx \
+  $ oasis-node consensus submit_tx \
+    --transaction.file /serverdir/signed-escrow.tx \
     -a unix:/serverdir/node/internal.sock
-  $ oasis-node registry entity submit \
+  $ oasis-node consensus submit_tx \
     --entity.transaction.file /serverdir/signed-register.tx \
     -a unix:/serverdir/node/internal.sock
   ```
@@ -544,11 +545,11 @@ To complete the staking process we need to submit your escrow transaction:
   Without docker:
 
   ```bash
-  $ oasis-node stake account submit \
-    --stake.transaction.file /serverdir/signed-escrow.tx \
+  $ oasis-node consensus submit_tx \
+    --transaction.file /serverdir/signed-escrow.tx \
     -a unix:/serverdir/node/internal.sock
-  $ oasis-node registry entity submit \
-    --entity.transaction.file /serverdir/signed-register.tx \
+  $ oasis-node consensus submit_tx \
+    --transaction.file /serverdir/signed-register.tx \
     -a unix:/serverdir/node/internal.sock
   ```
 

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -501,7 +501,7 @@ value used to track the account balance is 1x10^-18 tokens.
 ### Generating Entity Registration Transaction
 
 After you submit your escrow account, you'll need to register your entity so
-that it your node register properly. You could do this process _after_ you
+that your node register properly. You could do this process _after_ you
 submit the escrow transaction, however, to save steps we prepare everything
 before hand.
 

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -467,7 +467,7 @@ $ oasis-node stake account gen_escrow \
     --genesis.file $GENESIS_FILE_PATH \
     --entity $ENTITY_DIR_PATH \
     --stake.escrow.account $ACCOUNT_ID \
-    --stake.transaction.amount 100000000000000000000 \
+    --stake.amount 100000000000000000000 \
     --stake.transaction.file $OUTPUT_TX_FILE_PATH \
     --transaction.fee.gas 1000 \
     --transaction.fee.amount 1 \

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -170,7 +170,7 @@ In the `/serverdir` directory we will create the following subdirectories:
 You can make this directory structure by calling the following command:
 
 ```bash
-$ mkdir -p /serverdir/{etc,node/entity}
+$ mkdir -m700 -p /serverdir/{etc,node/entity}
 ```
 
 #### Copying the Node Artifacts from `/localhostdir`
@@ -315,6 +315,23 @@ tendermint:
   seed:
     - "[[ seed_node_address ]]"
 ```
+
+#### Ensuring proper permissions
+
+Only the owner of the process that runs node should have access to the files in
+the directory. We suggest running the following to remove all non-owner
+read/write/execute permissions:
+
+```bash
+chmod -R g-r,g-w,g-x,o-r,o-w,o-x /serverdir
+```
+
+However just so it's clear, the following permissions are expected by the
+`oasis-node` command:
+
+* `700` for the `/serverdir/node` directory
+* `700` for the `/serverdir/node/entity` directory
+* `600` for all `*.pem` files
 
 ### Starting the Oasis Node
 
@@ -466,7 +483,7 @@ The parameters are as follows:
 * `$ACCOUNT_ID` - This is the hex encoding of the Entity Public Key. To derive this you
   can use the following python3 code:
 
-  ```
+  ```python
   import binascii, base64
 
   def account_id_from_b64(base64_id):
@@ -499,7 +516,6 @@ $ oasis-node registry entity gen_register \
   transaction file. For this guide we will use
   `/localhostdir/signed-register.tx`
 
-
 ### Submitting Your Transactions on the `server`
 
 To complete the staking process we need to submit your escrow transaction:
@@ -512,7 +528,7 @@ To complete the staking process we need to submit your escrow transaction:
 
   If you're using docker use:
 
-  ```
+  ```bash
   $ docker exec -it oasis_node /bin/bash
   $ oasis-node stake account submit \
     --stake.transaction.file /serverdir/signed-escrow.tx \
@@ -524,7 +540,7 @@ To complete the staking process we need to submit your escrow transaction:
 
   Without docker:
 
-  ```
+  ```bash
   $ oasis-node stake account submit \
     --stake.transaction.file /serverdir/signed-escrow.tx \
     -a unix:/serverdir/node/internal.sock
@@ -544,8 +560,8 @@ Unfortunately, at this time this is a bit of a manual process.
 
 ### Getting the Node's consensus_pub.pem Identity
 
-```
-cat /serverdir/node/consensus_pub.pem
+```bash
+$ cat /serverdir/node/consensus_pub.pem
 ```
 
 This will look like:
@@ -563,7 +579,7 @@ We will use `s+vZ71qeZnlq0HmQSDBiWn2OKcy3fXOuPMu76/5GkUI=`. As the key to search
 Finally to see if the node is properly registered, run the command (you may need
 to be in a docker container if you are using that):
 
-```
+```bash
 $ export NODE_PUB_KEY="s+vZ71qeZnlq0HmQSDBiWn2OKcy3fXOuPMu76/5GkUI="
 $ oasis-node registry node list -v -a unix:/serverdir/node/internal.sock | grep $NODE_PUB_KEY
 ```

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -538,7 +538,7 @@ transactions:
     --transaction.file /serverdir/signed-escrow.tx \
     -a unix:/serverdir/node/internal.sock
   $ oasis-node consensus submit_tx \
-    --entity.transaction.file /serverdir/signed-register.tx \
+    --transaction.file /serverdir/signed-register.tx \
     -a unix:/serverdir/node/internal.sock
   ```
 

--- a/src/operators/maintenance/checking-account-nonce.md
+++ b/src/operators/maintenance/checking-account-nonce.md
@@ -1,8 +1,8 @@
 # Checking Your Account nonce
 
-If you need to submit new transactions to the network you will need to pull your
+If you need to submit new transactions to the network you will need to know your
 latest account nonce in order for the transaction submission to succeed. To
-determine your current nonce execute the following on your testnet node:
+determine your current nonce, execute the following on your testnet node:
 
 ```bash
 $ oasis-node stake account info \
@@ -10,7 +10,7 @@ $ oasis-node stake account info \
   -a unix:/serverdir/node/internal.sock
 ```
 
-The output will be json that look something like this (the output will be
+The output will be json that looks something like this (the output will be
 unformatted):
 
 ```json

--- a/src/operators/maintenance/checking-account-nonce.md
+++ b/src/operators/maintenance/checking-account-nonce.md
@@ -1,0 +1,38 @@
+# Checking Your Account nonce
+
+If you need to submit new transactions to the network you will need to pull your
+latest account nonce in order for the transaction submission to succeed. To
+determine your current nonce execute the following on your testnet node:
+
+```bash
+$ oasis-node stake account info \
+  --stake.account.id $ACCOUNT_ID_HEX \
+  -a unix:/serverdir/node/internal.sock
+```
+
+The output will be json that look something like this (the output will be
+unformatted):
+
+```json
+{
+  "id": "SOMEBASE64VALUEFORYOURACCOUNT11111111111111=",
+  "general_balance": "1000000000000000000",
+  "escrow_balance": "0",
+  "nonce": 101
+}
+```
+
+The `nonce` field will contain the nonce for your account. Use this value, `101`
+in this example, when generating transactions like so:
+
+```bash
+$ oasis-node stake account gen_escrow \
+  --genesis.file $GENESIS_FILE_PATH \
+  --entity $ENTITY_DIR_PATH \
+  --stake.escrow.account $ACCOUNT_ID \
+  --stake.amount 100000000000000000000 \
+  --transaction.file $OUTPUT_TX_FILE_PATH \
+  --transaction.fee.gas 1000 \
+  --transaction.fee.amount 1 \
+  --transaction.nonce 101
+```

--- a/src/operators/maintenance/wiping-node-state.md
+++ b/src/operators/maintenance/wiping-node-state.md
@@ -18,6 +18,7 @@ The following instructions assume that your `datadir` is defined as
     $ rm -rf /serverdir/node/tendermint
     $ rm -rf /serverdir/node/bleve-tag-index.bleve.db
     $ rm /serverdir/node/abci-mux-state.bolt.db
+    $ rm /serverdir/node/persistent-store.db
     ```
 
 3. Restart the oasis-node server process

--- a/src/operators/maintenance/wiping-node-state.md
+++ b/src/operators/maintenance/wiping-node-state.md
@@ -24,8 +24,14 @@ The following instructions assume that your `datadir` is defined as
 
 ## Full State Wipe
 
+::: danger WARNING
+This is likely not what you want to do. This is destructive and might result in
+losing private state required to operate the given node. **USE AT YOUR OWN
+RISK.**
+:::
+
 A full state wipe will also mean that you'll need to generate a new node
-identity (or copy the old one). This is likely not what you want.
+identity (or copy the old one).
 
 1. Stop the `oasis-node` server process (this will depend on your own deployment
    setup)

--- a/src/operators/prerequisites.md
+++ b/src/operators/prerequisites.md
@@ -35,41 +35,10 @@ params].
 [`master` branch]: https://github.com/oasislabs/oasis-core/tree/master/
 [params]: ./current-testnet-parameters.md
 
-### Using inside Docker
+### Using inside docker
 
-For those that wish to use the Oasis-provided Docker image, the `oasis-node`
-binary can be found inside the [oasis-node][oasis-node-docker] Docker image.
-
-To start a Docker container from this image, set the appropriate version by
-replacing `<DOCKER-IMAGE-VERSION>` with the version specified in the [Current
-Testnet Parameters][params] and run:
-
-```bash
-VERSION=<DOCKER-IMAGE-VERSION>
-docker run -it --rm \
-  --entrypoint /bin/bash \
-  --volume $(pwd):/workdir \
-  --workdir /workdir \
-  oasislabs/oasis-node:$VERSION
-```
-
-This invocation will set `/workdir` in the Docker container to the current
-working directory of the host.
-
-::: tip NOTE
-It is up to you to set this working directory correctly.
-If there are any strange errors, this is a common source of problems.
-:::
-
-Inside the container, you can use the `oasis-node` command as you would
-locally on your host.
-
-::: warning
-While the `latest` tag is available for the `oasis-node` Docker image, we
-suggest using the tag specified in the [Current Testnet Parameters][params] of
-the form `master-YYYYMMDDHHMMSS` to ensure that your node is compatible in case
-the `latest` tag doesn't match the tag specified in the [Current Testnet
-Parameters][params].
-:::
-
-[oasis-node-docker]: https://hub.docker.com/r/oasislabs/oasis-node
+For those that wish to use the Oasis provided docker container, the `oasis-node`
+binary can be accessed by running inside the context of a the
+[oasis-node](https://hub.docker.com/r/oasislabs/oasis-node) docker container.
+While possible to use, we no longer suggest nor do we support usage of the
+built docker containers.

--- a/src/operators/prerequisites.md
+++ b/src/operators/prerequisites.md
@@ -15,7 +15,7 @@ suggested, however, that you build from source yourself in a production
 deployment.
 
 Links to the binaries are provided in the [Current Testnet
-Parameters](./current-testnet-parameters.md) page
+Parameters](./current-testnet-parameters.md) page.
 
 ### Building from source
 

--- a/src/operators/prerequisites.md
+++ b/src/operators/prerequisites.md
@@ -8,6 +8,15 @@ repository's `go/` path. This binary contains both the logic for running an
 Oasis node and also provides a CLI for handling registry and staking
 operations.
 
+### Downloading the binary
+
+For convenience we provide binaries that have been built by Oasis Labs. It is
+suggested, however, that you build from source yourself in a production
+deployment.
+
+Links to the binaries are provided in the [Current Testnet
+Parameters](./current-testnet-parameters.md) page
+
 ### Building from source
 
 Although highly suggested, building from source is currently beyond the scope


### PR DESCRIPTION
We should be using the oasis-core commit `9d5e30082a5f3df065fc52a404e048decb9adac9` for these docs. Issues with that are being addressed now based on comments

corresponding docker image: `oasislabs/oasis-node:master-20191125134702`

FOR TESTING:
[test-genesis.json.zip](https://github.com/oasislabs/docs/files/3889353/test-genesis.json.zip)
SEED: `1AFFCD41DC221C5AD70E357F430BE84A6700ACF0@35.233.245.90:26656`