### PR TITLE
operators/prerequisites: use $OASIS_NODE_TAG instead of $VERSION

### DIFF
--- a/src/operators/prerequisites.md
+++ b/src/operators/prerequisites.md
@@ -38,7 +38,7 @@ $ docker run -it --rm \
    --entrypoint /bin/bash \
    --volume $(pwd):/workdir \
    --workdir /workdir \
-    oasislabs/oasis-node:$VERSION
+    oasislabs/oasis-node:$OASIS_NODE_TAG
 $ oasis-node --help
 ```
 


### PR DESCRIPTION
For consistency, use `$OASIS_NODE_TAG` instead of `$VERSION` for
addressing docker image tags.