### PR TITLE
operators: Remove debug section from sentry config

### DIFF
--- a/src/operators/sentry-node.md
+++ b/src/operators/sentry-node.md
@@ -326,6 +326,4 @@ tendermint:
   disable_peer_exchange: True
   db:
     backend: boltdb
-  debug:
-    addr_book_lenient: False
 ```


### PR DESCRIPTION
Even though it was set to `false` having a debug section in the config file looks wrong and someone may be tempted to set it to a dangerous value.