### PR TITLE
Add automatic linting with markdownlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: Continuous integration
+
+on: push
+
+jobs:
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Run markdownlint
+        # TODO: Expand this to other files in this repo.
+        run: npx markdownlint-cli src/operators/

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,24 @@
+# Markdownlint configuration.
+
+# For more information, see: https://github.com/DavidAnson/markdownlint#optionsconfig.
+
+# Enable all rules.
+default: true
+
+# Line Length.
+#
+# NOTE: The line_length rule is currently not strict enough.
+# For more details, see: https://github.com/DavidAnson/markdownlint/issues/237.
+MD013:
+  # Allow longer lines for code blocks since account ids are 64 characters long
+  # by themselves.
+  code_block_line_length: 99
+
+# Inline HTML.
+MD033:
+  allowed_elements:
+    # Allow raw <code> ... </code> elements because we use it as a work-around
+    # for lack of Vuepress' support for inline double curly braces that we use
+    # for denoting variables.
+    # For more details, see: https://github.com/vuejs/vuepress/issues/853.
+    - code

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ These docs are hosted at [docs.oasis.dev](https://docs.oasis.dev) and are built 
 
 You can help make these docs excellent by submitting issues and PRs for things that are unclear or need improvement.
 
-When adding new files, be sure to add the paths to [this file](./src/.vuepress/config.js), otherwise the files will not be displayed. 
+Before submitting a pull request, make sure to run `npx markdownlint-cli src/`
+and fix the reported Markdown issues.
+
+When adding new files, be sure to add the paths to [this file](./src/.vuepress/config.js), otherwise the files will not be displayed.
 
 ## Generating the docs
 

--- a/src/operators/architectural-overview.md
+++ b/src/operators/architectural-overview.md
@@ -4,8 +4,9 @@ As an operator of a Node on the Oasis Network, it is suggested that you have an
 understanding of the system architecture of the Oasis Network. Here we will
 provide a high level overview of the Oasis Network's architecture. This overview
 is used to provide enough guidance to be useful for the purposes of getting
-started as a Node Operator. Note that not all of these features are available in the Public Testnet, and their design may change in later phases. For more information on our proposed design, see
-[our research papers](https://www.oasis-protocol.org/researchpapers).
+started as a Node Operator. Note that not all of these features are available
+in the Public Testnet, and their design may change in later phases.
+For more information on our proposed design, see [our research papers][papers].
 
 ## Definitions
 
@@ -13,22 +14,20 @@ started as a Node Operator. Note that not all of these features are available in
 
 An Entity is an organization or individual with stake on the network. Each
 Entity has a private key that controls access to the wallet of the Entity. See
-[Entities and Key Management](#entities-and-key-management) for further
-information.
+[Entities and Key Management] for further information.
 
 ### Node
 
 A Node is a device (VM, Bare Metal, Container, etc.) that is participating in a
 committee on the Network. Each Node has a private key that is used for signing
 operations during block production and a public key, or Node Identity, used for
-identification. See [Entities and Key Management](#entities-and-key-management)
-for further information.
+identification. See [Entities and Key Management] for further information.
 
 ### Committee
 
 A Committee is a set of Nodes that are participating in the same service layer
 of the Oasis Network. Committees are described in more detail in the [Modular
-Architecture](#modular-architecture) section.
+Architecture] section.
 
 ## Modular Architecture
 
@@ -46,11 +45,11 @@ different classes Nodes and potentially to different hardware.
 ![Transaction Processing](/operator_images/web3_diagram_v2.png)
 
 In the figure above, we see the flow of transactions in each committee. The
-details of each committee is best described in our [research
-paper](https://www.oasis-protocol.org/researchpapers), but we provide this section here
-as a high level introduction. It should be noted that some aspects of the system
-are yet to be completed. So the testnet that you might deploy in the [Quick
-Start Guide](./quick-start.md) won't yet function as it is described here.
+details of each committee is best described in [our research papers][papers],
+but we provide this section here as a high level introduction.
+It should be noted that some aspects of the system are yet to be completed.
+So the testnet that you might deploy in the [Quick Start Guide] won't yet
+function as it is described here.
 
 #### Registry
 
@@ -87,9 +86,8 @@ The Oasis Network uses three different protocols for communication:
 
 Confidentiality is achieved in the Oasis Network by relying on trusted execution
 environments (TEEs) to secure the execution of any given smart contract.
-Initially, the Oasis Network will utilize [Intel
-SGX](https://software.intel.com/en-us/sgx). As more TEE technologies mature, we
-expect to support more than TEEs than Intel SGX.
+Initially, the Oasis Network will utilize [Intel SGX]. As more TEE technologies
+mature, we expect to support more than TEEs than Intel SGX.
 
 ## Entities and Key Management
 
@@ -106,3 +104,9 @@ key management model for node operators. The model is as follows:
   * A Node is a block producing node on the Oasis Network
   * Each Node's key pair is used for:
     * Signing actions during block production
+
+[papers]: https://www.oasis-protocol.org/researchpapers
+[Entities and Key Management]: #entities-and-key-management
+[Modular Architecture]: #modular-architecture
+[Quick Start Guide]: ./quick-start.md
+[Intel SGX]: https://software.intel.com/en-us/sgx

--- a/src/operators/incentives-proposal.md
+++ b/src/operators/incentives-proposal.md
@@ -1,85 +1,188 @@
 # Oasis Network Incentives: A Proposal for the Network at Time of Launch
 
-*NOTE: This is a draft proposal and is subject to change pending the outcome of an economic audit, feedback from the community, and the results of the Oasis Foundation’s staking competition.* 
+::: tip NOTE
+This is a draft proposal and is subject to change pending the outcome of an
+economic audit, feedback from the community, and the results of the Oasis
+Foundation’s staking competition.
+:::
 
-Below is a proposal of the initial incentive model for the Oasis Network at the time of Mainnet launch. To submit your feedback and comments to the proposal please reach out to us on [Slack](https://www.oasis-protocol.org/slack) or via [GitHub](https://github.com/oasislabs/docs). When designing and running stress tests, audits, and simulations, the underlying goal has been to develop an incentive model that encourages both the development of a healthy and active developer ecosystem as well as a secure, decentralized network through an engaged and diverse node operator community.
+Below is a proposal of the initial incentive model for the Oasis Network at the
+time of Mainnet launch. To submit your feedback and comments to the proposal
+please reach out to us on [Slack] or via [GitHub][github-docs].
+When designing and running stress tests, audits, and simulations, the
+underlying goal has been to develop an incentive model that encourages both the
+development of a healthy and active developer ecosystem as well as a secure,
+decentralized network through an engaged and diverse node operator community.
 
-The core focus of this incentive documentation is to outline a proposal for parameters and rewards around staking and delegation. In future documentation we will provide more detail on the proposed roadmap and rewards that expand beyond this activity.
+The core focus of this incentive documentation is to outline a proposal for
+parameters and rewards around staking and delegation.
+In future documentation we will provide more detail on the proposed roadmap and
+rewards that expand beyond this activity.
+
+[Slack]: https://www.oasis-protocol.org/slack
+[gitHub-docs]: https://github.com/oasislabs/docs
 
 ## Summary
 
-* **Estimated staking rewards**: 15% APR at launch, tapering to 10% by end of year.
+* **Estimated staking rewards**: 15% APR at launch, tapering to 10% by end of
+  year.
 * **Slashing**: Slash for double-signing only
-* **Number of validators to participate in any given consensus committee (and receive staking rewards) at launch**: up to 100 validators
+* **Number of validators to participate in any given consensus committee (and
+  receive staking rewards) at launch**: up to 100 validators
 * **Minimum stake**: 100 tokens
 
 ## Overview of the Oasis Consensus Layer
-The Oasis Network is based on a Proof-of-Stake (PoS) consensus model. Tokens can be self-delegated directly by each node operator or delegated to a node operator by other token holders. While the Oasis Network is designed with a modular architecture that can use any consensus system that satisfies these properties, it currently uses [Tendermint](https://github.com/tendermint/tendermint) as its consensus algorithm. 
 
-At the time of the initial Mainnet launch, node operators will primarily serve as validators for this consensus layer. They will have the ability to sign blocks, earn transaction fees, stake, and receive delegation. Similar to the PoS design implemented by Cosmos, up to 100 validators with the most stake will be active validators participating in the consensus process. 
+The Oasis Network is based on a Proof-of-Stake (PoS) consensus model. Tokens
+can be self-delegated directly by each node operator or delegated to a node
+operator by other token holders. While the Oasis Network is designed with a
+modular architecture that can use any consensus system that satisfies these
+properties, it currently uses [Tendermint] as its consensus algorithm.
 
-The system will disincentivize bad behavior via slashing for double-signing, as well as via the cost to dominate the network, in terms of the number of staked tokens. 
+At the time of the initial Mainnet launch, node operators will primarily serve
+as validators for this consensus layer. They will have the ability to sign
+blocks, earn transaction fees, stake, and receive delegation. Similar to the
+PoS design implemented by Cosmos, up to 100 validators with the most stake will
+be active validators participating in the consensus process.
+
+The system will disincentivize bad behavior via slashing for double-signing, as
+well as via the cost to dominate the network, in terms of the number of staked
+tokens.
+
+[Tendermint]: https://github.com/tendermint/tendermint
 
 ## Nuts and Bolts of Staking Rewards
 
 ### Staking Conditions
-As a public, permissionless blockchain platform, our goal is to make the experience of setting up a node as seamless as possible for any member of our community who wants to contribute to the Oasis Network. To that end, we’ve put a lot of thought into ensuring our staking conditions minimize barriers to entry and encourage meaningful engagement on the network. A few key parameters:
 
-* **Number of validators to participate in consensus committee (and receive staking rewards) at launch**: Up to 100 validators
+As a public, permissionless blockchain platform, our goal is to make the
+experience of setting up a node as seamless as possible for any member of our
+community who wants to contribute to the Oasis Network. To that end, we’ve put
+a lot of thought into ensuring our staking conditions minimize barriers to
+entry and encourage meaningful engagement on the network. A few key parameters:
+
+* **Number of validators to participate in consensus committee (and receive
+  staking rewards) at launch**: Up to 100 validators
 
 * **Minimum stake**: 100 tokens
 
-* **Selection to the consensus committee**: Each entity can have at most one node elected to the consensus committee at a time. The probability of selection to the consensus committee is proportional to the stake of all nodes run by one entity.
+* **Selection to the consensus committee**: Each entity can have at most one
+  node elected to the consensus committee at a time. The probability of
+  selection to the consensus committee is proportional to the stake of all
+  nodes run by one entity.
 
-* **Annual rewards**: The network is targeted to hit ~15% APR at launch (based on the number of blocks produced, so timing could vary) and then taper down to 10% by end of year. This will happen over a gradual taper rather than a step function change to avoid creating some sort of cliff. 
+* **Annual rewards**: The network is targeted to hit ~15% APR at launch (based
+  on the number of blocks produced, so timing could vary) and then taper down
+  to 10% by end of year. This will happen over a gradual taper rather than a
+  step function change to avoid creating some sort of cliff.
 
-* **Slashing**: At the time of Mainnet launch, the network will only slash for double-signing. The network would slash the minimum stake amount (100 tokens) and freeze the node. Freezing the node is a precaution in order to prevent the node from being over-penalized. The Network will not slash for liveness or uptime at launch.
+* **Slashing**: At the time of Mainnet launch, the network will only slash for
+  double-signing. The network would slash the minimum stake amount (100 tokens)
+  and freeze the node. Freezing the node is a precaution in order to prevent
+  the node from being over-penalized. The Network will not slash for liveness
+  or uptime at launch.
 
-* **Staking rewards**: The goal initially is to offer rewards that will help bootstrap the network effectively. To start, rewards will be proportional to the stake and awarded on a per-entity basis. In order to be eligible for staking rewards per epoch, a node would need to sign at least 75% of blocks in that epoch.
+* **Staking rewards**: The goal initially is to offer rewards that will help
+  bootstrap the network effectively. To start, rewards will be proportional to
+  the stake and awarded on a per-entity basis. In order to be eligible for
+  staking rewards per epoch, a node would need to sign at least 75% of blocks
+  in that epoch.
 
-* **Unbonding period**: The network will have a ~14 day unbonding period. During this time, staked tokens are at risk of getting slashed for double-signing and do not accrue rewards during this time.
+* **Unbonding period**: The network will have a ~14 day unbonding period.
+  During this time, staked tokens are at risk of getting slashed for
+  double-signing and do not accrue rewards during this time.
 
-* **Consensus Voting power**: During the staking competition, we plan to run various tests to help us determine whether to distribute consensus voting power on the network through a stake-weighted system or to leverage a non-weighted, flat voting approach. Expect more here in the future.
+* **Consensus Voting power**: During the staking competition, we plan to run
+various tests to help us determine whether to distribute consensus voting power
+on the network through a stake-weighted system or to leverage a non-weighted,
+flat voting approach. Expect more here in the future.
 
 ### Delegation
-As the Oasis Network gets closer to Mainnet, we’ll continue to share with our community plenty of additional information on the delegation process and how to do easily delegate on the network. In the meantime, here are a few thoughts on delegation more generally:
+
+As the Oasis Network gets closer to Mainnet, we’ll continue to share with our
+community plenty of additional information on the delegation process and how to
+do easily delegate on the network. In the meantime, here are a few thoughts on
+delegation more generally:
 
 * **Slashing**: Delegated funds can be slashed for double-signing.
 
-* **Reward disbursement**: Rewards from delegated funds are distributed directly to the delegator. Rewards are automatically added to their stakes (i.e. reinvested), so the rewards will have to go through the ~14 day unbonding period.
+* **Reward disbursement**: Rewards from delegated funds are distributed
+  directly to the delegator. Rewards are automatically added to their stakes
+  (i.e. reinvested), so the rewards will have to go through the ~14 day
+  unbonding period.
 
 ### Commission Rates
-There is currently no plan to require a minimum or maximum commission rate for delegation, but we would like to set parameters around the transparency and notification of commission rates. 
 
-When a node sets up on network, it will be able to share its current commission rate, as well as the range with which that rate could change (e.g. + / - 10%). Commission rates can be adjusted once per day.
+There is currently no plan to require a minimum or maximum commission rate for
+delegation, but we would like to set parameters around the transparency and
+notification of commission rates.
+
+When a node sets up on network, it will be able to share its current commission
+rate, as well as the range with which that rate could change (e.g. + / - 10%).
+Commission rates can be adjusted once per day.
 
 ### Transaction Fee Distribution
-Most likely, transaction fees will be distributed equally among validators who signed the block containing that specific transaction.
+
+Most likely, transaction fees will be distributed equally among validators who
+signed the block containing that specific transaction.
 
 ## Glossary of Commonly Used Terms
 
-* **Entity**: That’s you! (Or your organization.) On the Oasis Network, you’re identified by your public key. Your private key controls your wallet, which maintains a token balance. Each entity can also have a token amount staked, which is a separate balance that permits it to run *nodes*. See [Entities and Key Management](https://docs.oasis.dev/operators/architectural-overview.html#entities-and-key-management) for further information.
+* **Entity**: That’s you! (Or your organization.) On the Oasis Network, you’re
+identified by your public key. Your private key controls your wallet, which
+maintains a token balance. Each entity can also have a token amount staked,
+which is a separate balance that permits it to run *nodes*.
+See [Entities and Key Management] for further information.
 
-* **Node**: This is your computer (VM, bare metal, container, etc.), running the Oasis Network software. It’s identified by another public key, separate from your entity public key. On the Oasis Network, each node is owned by a single entity. For each node that an entity registers on the network, the entity must have a certain additional token amount *staked*.
+* **Node**: This is your computer (VM, bare metal, container, etc.), running
+  the Oasis Network software. It’s identified by another public key, separate
+  from your entity public key. On the Oasis Network, each node is owned by a
+  single entity. For each node that an entity registers on the network, the
+  entity must have a certain additional token amount *staked*.
 
-* **Staking**: A token amount *staked* with an entity is separate from the entity’s token balance and contributes to the entity’s eligibility to run nodes. Entities can *stake* tokens with themselves or with other entities, the latter is referred to as *delegation*. The network keeps track of which entities delegated what proportion of an entity’s staked token amount.
+* **Staking**: A token amount *staked* with an entity is separate from the
+  entity’s token balance and contributes to the entity’s eligibility to run
+  nodes. Entities can *stake* tokens with themselves or with other entities,
+  the latter is referred to as *delegation*. The network keeps track of which
+  entities delegated what proportion of an entity’s staked token amount.
 
-* **Consensus committee**: The consensus committee is a group of nodes that the network elects to maintain its state by executing a Byzantine-fault-tolerant (BFT) consensus protocol.
+* **Consensus committee**: The consensus committee is a group of nodes that the
+  network elects to maintain its state by executing a Byzantine-fault-tolerant
+  (BFT) consensus protocol.
 
-* **Validator**: A validator is a node participating in the consensus committee. To be eligible to have your node selected as a validator, your entity must be within the Top K staked entities. Entities with a node serving as a validator receive *staking rewards*, which are shared with delegators, as well as *transaction fees*, which are deposited only into their own wallet. Each validator has a private key that is used for signing operations during block production and a public key, or Node Identity, used for identification. See [Entities and Key Management](https://docs.oasis.dev/operators/architectural-overview.html#entities-and-key-management) for further information.
+* **Validator**: A validator is a node participating in the consensus
+  committee. To be eligible to have your node selected as a validator, your
+  entity must be within the Top K staked entities. Entities with a node serving
+  as a validator receive *staking rewards*, which are shared with delegators,
+  as well as *transaction fees*, which are deposited only into their own
+  wallet. Each validator has a private key that is used for signing operations
+  during block production and a public key, or Node Identity, used for
+  identification. See [Entities and Key Management] for further information.
 
-* **Top K**: The top-ranked entities by token amount staked. These entities’ nodes are eligible to participate in the consensus committee and receive staking rewards.
+* **Top K**: The top-ranked entities by token amount staked. These entities’
+  nodes are eligible to participate in the consensus committee and receive
+  staking rewards.
 
-* **Transaction fee**: The reward that a validator receives from processing a transaction that runs on the network (separate from staking rewards).
+* **Transaction fee**: The reward that a validator receives from processing a
+  transaction that runs on the network (separate from staking rewards).
 
-* **Commission rate**: The fee that a validator chooses to charge to delegators.
+* **Commission rate**: The fee that a validator chooses to charge to
+  delegators.
 
-* **Unbonding period**: A period of time when a validator or delegator wants to stop staking tokens, but cannot move them. During this waiting period, tokens do not accrue staking rewards but cannot be withdrawn.
+* **Unbonding period**: A period of time when a validator or delegator wants to
+  stop staking tokens, but cannot move them. During this waiting period, tokens
+  do not accrue staking rewards but cannot be withdrawn.
+
+[Entities and Key Management]: ./architectural-overview.html#entities-and-key-management
 
 *****
-For more information and for the latest updates, please visit our website. We also invite you to join our Slack community to share your feedback and help shape the future of our network. 
+For more information and for the latest updates, please visit our website.
+We also invite you to join our Slack community to share your feedback and help
+shape the future of our network.
+
 If you’re new to Oasis, here are some resources you may find useful:
-* [Oasis Foundation Website](https://www.oasis-protocol.org) 
+
+* [Oasis Foundation Website](https://www.oasis-protocol.org)
 * [Testnet Documentation](https://docs.oasis.dev/operators/joining-the-testnet.html)
 * [Operator Documentation](https://docs.oasis.dev/operators/overview.html)
 * [GitHub](https://www.github.com/oasislabs)

--- a/src/operators/joining-the-testnet.md
+++ b/src/operators/joining-the-testnet.md
@@ -5,6 +5,7 @@ assumption of knowledge on the use of basic command line tools.
 
 ::: tip NOTE
 If you joined the Testnet prior to 11/26, use the following steps to upgrade:
+
 1. [Stop your node and wipe state (keep node identity)](./maintenance/wiping-node-state.md)
 1. [Download the current genesis file and `oasis-node` to your
    server](./current-testnet-parameters.md)
@@ -51,15 +52,16 @@ following directories:
   are safest if used on a machine kept disconnected from the internet. The
   directory permissions should be `rwx------`
 * `node` - This will store a node we are calling "node". The name is not
-  important. It simply represents one of your nodes. You can rename it to whatever you
-  wish. The private contents of this directory will be used on the node itself.
+  important. It simply represents one of your nodes. You can rename it to
+  whatever you wish. The private contents of this directory will be used on the
+  node itself.
   You should initialize this information on a system with access to the entity's
   private key. The directory permissions should be `rwx------`
 
 To create the directory structure, use the following command:
 
 ```bash
-$ mkdir -m700 -p {entity,node}
+mkdir -m700 -p {entity,node}
 ```
 
 ### Copying the Genesis File
@@ -67,8 +69,9 @@ $ mkdir -m700 -p {entity,node}
 The latest genesis file can be found [here](./current-testnet-parameters.md).
 You should download the latest `genesis.json` file, copy it to the working
 directory and save its path into an environment variable:
+
 ```bash
-$ export GENESIS_FILE_PATH=/localhostdir/genesis.json
+export GENESIS_FILE_PATH=/localhostdir/genesis.json
 ```
 
 This will be needed later when generating transactions.
@@ -88,8 +91,8 @@ However, it is up to you to determine your own security practices.
 
 To initialize an entity simply run the following from `/localhostdir/entity`:
 
-```
-$ oasis-node registry entity init
+```bash
+oasis-node registry entity init
 ```
 
 This will generate 3 files in `/localhostdir/entity`
@@ -112,8 +115,8 @@ server where your node will run, and issue the following commands from the
 `/localhostdir/node` directory.
 
 ```bash
-$ export STATIC_IP=<YOUR_STATIC_IP>
-$ oasis-node registry node init \
+export STATIC_IP=<YOUR_STATIC_IP>
+oasis-node registry node init \
   --entity /localhostdir/entity \
   --node.consensus_address $STATIC_IP:26656 \
   --node.is_self_signed \
@@ -145,8 +148,8 @@ so that it can properly register itself when the node starts up.
 
 Execute the following command in the `/localhostdir/node` directory:
 
-```
-$ oasis-node registry entity update \
+```bash
+oasis-node registry entity update \
   --datadir /localhostdir/entity \
   --entity.node.descriptor node_genesis.json
 ```
@@ -183,7 +186,7 @@ In the `/serverdir` directory we will create the following subdirectories:
 You can make this directory structure by calling the following command:
 
 ```bash
-$ mkdir -m700 -p /serverdir/{etc,node,node/entity}
+mkdir -m700 -p /serverdir/{etc,node,node/entity}
 ```
 
 #### Copying the Node Artifacts from `/localhostdir`
@@ -302,8 +305,8 @@ genesis:
 # Worker configuration.
 worker:
   registration:
-    # In order for the node to register itself the entity.json of the entity used to
-    # provision the node must be available on the node
+    # In order for the node to register itself the entity.json of the entity
+    # used to provision the node must be available on the node.
     entity: /serverdir/node/entity/entity.json
 
 # Consensus backend.
@@ -372,7 +375,7 @@ process supervisor like [supervisord](http://supervisord.org/),
 [systemd](https://github.com/systemd/systemd), etc.
 
 ```bash
-$ oasis-node --config /serverdir/etc/config.yml
+oasis-node --config /serverdir/etc/config.yml
 ```
 
 ### Verifying the Connection to the Network
@@ -384,7 +387,7 @@ can be used to communicate to the node and query details about the network.
 Run the following command:
 
 ```bash
-$ oasis-node registry entity list -a unix:/serverdir/node/internal.sock
+oasis-node registry entity list -a unix:/serverdir/node/internal.sock
 ```
 
 If this command fails, you'll receive a non-zero exit code and there's a high
@@ -392,7 +395,7 @@ likelihood that you are not connected to the network. However, if it does work
 properly it should respond with output like the following but with potentially
 many more values:
 
-```
+```text
 2317a8eef10e470434411aebac8f1a8c0f1c6a0d35ff53921f8bc70588bb66b2
 8e3873f84f7f2250eb456dc598dc56b812f561137fe41c383128e6c14e0e2e74
 cf3b004bd98f3e1eab92e97c5fa6cbe4d42a00133c515a2440fefaca514a48ff
@@ -458,7 +461,7 @@ Before you can make any transactions you'll have to make sure that node is
 synced. To do so call this command on the server:
 
 ```bash
-$ oasis-node control is-synced \
+oasis-node control is-synced \
   -a unix:/serverdir/node/internal.sock && \
   echo "You are synced" || echo "You are not synced"
 ```
@@ -483,16 +486,16 @@ minimum stake required to register an entity and register a node as a validator
 is 100 tokens. So we will generate an escrow transaction that escrows 100 tokens
 on your own Entity.
 
-```
-$ oasis-node stake account gen_escrow \
-    --genesis.file $GENESIS_FILE_PATH \
-    --entity $ENTITY_DIR_PATH \
-    --stake.escrow.account $ACCOUNT_ID \
-    --stake.amount 100000000000000000000 \
-    --transaction.file $OUTPUT_TX_FILE_PATH \
-    --transaction.fee.gas 1000 \
-    --transaction.fee.amount 1 \
-    --transaction.nonce 0
+```bash
+oasis-node stake account gen_escrow \
+  --genesis.file $GENESIS_FILE_PATH \
+  --entity $ENTITY_DIR_PATH \
+  --stake.escrow.account $ACCOUNT_ID \
+  --stake.amount 100000000000000000000 \
+  --transaction.file $OUTPUT_TX_FILE_PATH \
+  --transaction.fee.gas 1000 \
+  --transaction.fee.amount 1 \
+  --transaction.nonce 0
 ```
 
 The parameters are as follows:
@@ -500,8 +503,8 @@ The parameters are as follows:
 * `$ENTITY_DIR_PATH` - For this guide this would be `/localhostdir/entity/`
 * `$OUTPUT_TX_FILE_PATH` - This is where you wish to output the signed
   transaction file. For this guide we will use `/localhostdir/signed-escrow.tx`
-* `$ACCOUNT_ID` - This is the hex encoding of the Entity Public Key. To derive this you
-  can use the following python3 code:
+* `$ACCOUNT_ID` - This is the hex encoding of the Entity Public Key. To derive
+  this you can use the following python3 code:
 
   ```python
   import binascii, base64
@@ -526,7 +529,7 @@ submit the escrow transaction, however, to save steps we prepare everything
 before hand.
 
 ```bash
-$ oasis-node registry entity gen_register \
+oasis-node registry entity gen_register \
   --genesis.file $GENESIS_FILE_PATH \
   --entity $ENTITY_DIR_PATH \
   --transaction.file $OUTPUT_REGISTER_TX_FILE_PATH \
@@ -552,10 +555,10 @@ transactions:
 3. Call `oasis-node` like so:
 
   ```bash
-  $ oasis-node consensus submit_tx \
+  oasis-node consensus submit_tx \
     --transaction.file /serverdir/signed-escrow.tx \
     -a unix:/serverdir/node/internal.sock
-  $ oasis-node consensus submit_tx \
+  oasis-node consensus submit_tx \
     --transaction.file /serverdir/signed-register.tx \
     -a unix:/serverdir/node/internal.sock
   ```
@@ -572,31 +575,34 @@ Unfortunately, at this time this is a bit of a manual process.
 ### Getting the Node's consensus_pub.pem Identity
 
 ```bash
-$ cat /serverdir/node/consensus_pub.pem
+cat /serverdir/node/consensus_pub.pem
 ```
 
 This will look like:
 
-```
+```text
 -----BEGIN ED25519 PUBLIC KEY-----
 s+vZ71qeZnlq0HmQSDBiWn2OKcy3fXOuPMu76/5GkUI=
 -----END ED25519 PUBLIC KEY-----
 ```
 
-We will use `s+vZ71qeZnlq0HmQSDBiWn2OKcy3fXOuPMu76/5GkUI=`. As the key to search for.
+We will use `s+vZ71qeZnlq0HmQSDBiWn2OKcy3fXOuPMu76/5GkUI=` as the key to search
+for.
 
 ### grepping for the Node's Identity
 
 Finally to see if the node is properly registered, run the command:
 
 ```bash
-$ export NODE_PUB_KEY="s+vZ71qeZnlq0HmQSDBiWn2OKcy3fXOuPMu76/5GkUI="
-$ oasis-node registry node list -v -a unix:/serverdir/node/internal.sock | grep $NODE_PUB_KEY
+export NODE_PUB_KEY="s+vZ71qeZnlq0HmQSDBiWn2OKcy3fXOuPMu76/5GkUI="
+oasis-node registry node list -v -a unix:/serverdir/node/internal.sock | grep $NODE_PUB_KEY
 ```
 
 If `grep` found the key, then you're properly connected!
 
+<!-- markdownlint-disable no-trailing-punctuation -->
 ## You're a Validator!
+<!-- markdownlint-enable no-trailing-punctuation -->
 
 If you've made it this far you've properly connected your node to the network
 and you're now a Validator on the Public Testnet.

--- a/src/operators/maintenance/checking-account-nonce.md
+++ b/src/operators/maintenance/checking-account-nonce.md
@@ -5,7 +5,7 @@ latest account nonce in order for the transaction submission to succeed. To
 determine your current nonce, execute the following on your testnet node:
 
 ```bash
-$ oasis-node stake account info \
+oasis-node stake account info \
   --stake.account.id $ACCOUNT_ID_HEX \
   -a unix:/serverdir/node/internal.sock
 ```
@@ -26,7 +26,7 @@ The `nonce` field will contain the nonce for your account. Use this value, `101`
 in this example, when generating transactions like so:
 
 ```bash
-$ oasis-node stake account gen_escrow \
+oasis-node stake account gen_escrow \
   --genesis.file $GENESIS_FILE_PATH \
   --entity $ENTITY_DIR_PATH \
   --stake.escrow.account $ACCOUNT_ID \

--- a/src/operators/maintenance/wiping-node-state.md
+++ b/src/operators/maintenance/wiping-node-state.md
@@ -15,10 +15,10 @@ The following instructions assume that your `datadir` is defined as
 2. Remove blockchain state
 
     ```bash
-    $ rm -rf /serverdir/node/tendermint
-    $ rm -rf /serverdir/node/bleve-tag-index.bleve.db
-    $ rm /serverdir/node/abci-mux-state.bolt.db
-    $ rm /serverdir/node/persistent-store.db
+    rm -rf /serverdir/node/tendermint
+    rm -rf /serverdir/node/bleve-tag-index.bleve.db
+    rm /serverdir/node/abci-mux-state.bolt.db
+    rm /serverdir/node/persistent-store.db
     ```
 
 3. Restart the oasis-node server process

--- a/src/operators/overview.md
+++ b/src/operators/overview.md
@@ -10,7 +10,10 @@ In the coming months, the code and tooling will become available for the general
 public to join the Oasis Network. The Node Operator docs available here will be
 continuously updated as more information becomes available.
 
-If you run into any issues or have a question, you can chat with us in our public [Slack channel](https://join.slack.com/t/oasiscommunity/shared_invite/enQtNjQ5MTA3NTgyOTkzLWIxNTg1ZWZmOTIwNmQ2MTg1YmU0MzgyMzk3OWM2ZWQ4NTQ0ZDJkNTBmMTdlM2JhODllYjg5YmJkODc2NzgwNTg).
+If you run into any issues or have a question, you can chat with us in our
+[public Slack channel][slack].
+
+[slack]: https://join.slack.com/t/oasiscommunity/shared_invite/enQtNjQ5MTA3NTgyOTkzLWIxNTg1ZWZmOTIwNmQ2MTg1YmU0MzgyMzk3OWM2ZWQ4NTQ0ZDJkNTBmMTdlM2JhODllYjg5YmJkODc2NzgwNTg
 
 ## Oasis Network Roadmap
 

--- a/src/operators/sentry-node.md
+++ b/src/operators/sentry-node.md
@@ -32,8 +32,8 @@ Before following this guide, make sure you've read the [Prerequisites] and
 
 Sentry node identity keys can be initialized with:
 
-```
-$ oasis-node registry node init --entity /localhostdir/entity
+```bash
+oasis-node registry node init --entity /localhostdir/entity
 ```
 
 The generated `tls_identity_cert.pem` (which is the node's TLS cert for
@@ -77,9 +77,11 @@ the following section
 - <code v-pre>{{ validator_tendermint_id }}</code>: This is the Tendermint ID of
   the Oasis validator node that will be protected by the sentry node. This ID
   can be obtained by running:
+
+  ```bash
+  oasis-node debug tendermint show-node-id --datadir /serverdir/node
   ```
-  $ oasis-node debug tendermint show-node-id --datadir /serverdir/node
-  ```
+
   on the validator node.
 
   <!--- TODO: there is probably a different way to get this out of our identity
@@ -162,9 +164,9 @@ Multiple sentry nodes can be provisioned following the above steps.
 
 ## Configuring the Oasis Validator Node
 
-In this setup the Oasis validator node should not be exposed directly on the public
-network. The Oasis validator only needs to be able to connect to its sentry nodes, preferably
-via a private network.
+In this setup the Oasis validator node should not be exposed directly on the
+public network. The Oasis validator only needs to be able to connect to its
+sentry nodes, preferably via a private network.
 
 ### Initializing Validator Node
 
@@ -182,10 +184,10 @@ If you are running multiple sentry nodes, you can specify the
 To initialize a validator node with 2 sentry nodes' external addresses, run the
 following commands from the `/localhostdir/node` directory:
 
-```
-$ export SENTRY1_STATIC_IP=<YOUR_SENTRY1_STATIC_IP>
-$ export SENTRY2_STATIC_IP=<YOUR_SENTRY2_STATIC_IP>
-$ oasis-node registry node init \
+```bash
+export SENTRY1_STATIC_IP=<YOUR_SENTRY1_STATIC_IP>
+export SENTRY2_STATIC_IP=<YOUR_SENTRY2_STATIC_IP>
+oasis-node registry node init \
   --entity /localhostdir/entity \
   --node.consensus_address $SENTRY1_STATIC_IP:26656 \
   --node.consensus_address $SENTRY2_STATIC_IP2:26656 \
@@ -243,9 +245,11 @@ file:
 - `sentry_node_tendermint_id`: This is the Tendermint ID of the sentry node
   that will be configured as a Persistent Peer. This ID can be obtained by
   running:
+
+  ```bash
+  oasis-node debug tendermint show-node-id --datadir /serverdir/node
   ```
-  $ oasis-node debug tendermint show-node-id --datadir /serverdir/node
-  ```
+
   on the sentry node.
 
   <!--- TODO: there is probably a different way to get this out of our identity
@@ -298,8 +302,8 @@ genesis:
 # Worker configuration.
 worker:
   registration:
-    # In order for the node to register itself the entity.json of the entity used to
-    # provision the node must be available on the node
+    # In order for the node to register itself the entity.json of the entity
+    # used to provision the node must be available on the node.
     entity: /serverdir/node/entity/entity.json
   sentry:
     address:

--- a/src/operators/stake-management.md
+++ b/src/operators/stake-management.md
@@ -4,6 +4,7 @@ For node operators the `oasis-node` binary offers a command line interface for
 various staking token operations.
 
 The following commands are intended to be run **online**:
+
 * `oasis-node stake info` shows the token information,
 * `oasis-node stake list` lists all accounts with positive balance,
 * `oasis-node stake account info` shows detailed account information,
@@ -13,6 +14,7 @@ filename.
 In addition, the following commands generate transactions and are meant to be
 run offline, because signing transactions requires a private key which **should
 not be accessible** from outside in any way:
+
 * `oasis-node stake account gen_transfer`
 * `oasis-node stake account gen_burn`
 * `oasis-node stake account gen_escrow`
@@ -25,9 +27,9 @@ binary available, a genesis file location stored in an environmental variable `$
 and the private keypair of your entity in a directory `$ENTITY_DIR_PATH`.
 Additionally, we will use `$ADDR` containing the location of the internal socket,
 of the Oasis node, for example
- 
+
 ```bash
-$ export ADDR=unix:/tmp/oasis-net-runner236357163/net-runner/network/client-0/internal.sock
+export ADDR=unix:/tmp/oasis-net-runner236357163/net-runner/network/client-0/internal.sock
 ```
 
 We will provide the `-a $ADDR` parameter to any operation which requires
@@ -62,6 +64,7 @@ $ oasis-node stake list -a $ADDR
 
 There exists one such account `4ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35`.
 For more information about the account, run:
+
 ```bash
 $ oasis-node stake account info \
     -a $ADDR \
@@ -70,6 +73,7 @@ $ oasis-node stake account info \
 ```
 
 We notice that:
+
 * `id` stores the Base64-encoded address of the account.
 * `general_balance` is the number of tokens which can be spent by a transfer
   transaction signed by the account's private key.
@@ -85,18 +89,20 @@ Next, we will generate and sign our first transaction. Let's start with a *burn*
 transaction, which destroys the given number of tokens. To generate a
 burn transaction of 2000 tokens, sign and store the transaction to file `b.json`,
 type:
+
 ```bash
-$ oasis-node stake account gen_burn \
-    --genesis.file $GENESIS_FILE_PATH \
-    --entity $ENTITY_DIR_PATH \
-    --stake.transaction.amount 2000 \
-    --stake.transaction.file b.json \
-    --stake.transaction.nonce 0 \
-    --stake.transaction.fee.gas 1000 \
-    --stake.transaction.fee.amount 1
+oasis-node stake account gen_burn \
+  --genesis.file $GENESIS_FILE_PATH \
+  --entity $ENTITY_DIR_PATH \
+  --stake.transaction.amount 2000 \
+  --stake.transaction.file b.json \
+  --stake.transaction.nonce 0 \
+  --stake.transaction.fee.gas 1000 \
+  --stake.transaction.fee.amount 1
 ```
 
 We used the following parameters:
+
 * `--stake.transaction.amount` specifying the number of tokens,
 * `--stake.transaction.file` the output filename of the transaction stored in
 JSON format,
@@ -111,14 +117,16 @@ The above generation and signing of the transaction can be done offline.
 
 To submit our transaction, we need to copy `b.json` to a location accessible by
 the online Oasis node (e.g. via ssh) and run on the server:
+
 ```bash
-$ oasis-node stake account submit \
-    -a $ADDR \
-    --stake.account.id 4ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35 \
-    --stake.transaction.file b.json
+oasis-node stake account submit \
+  -a $ADDR \
+  --stake.account.id 4ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35 \
+  --stake.transaction.file b.json
 ```
 
 Beside the node's address, the submit operation above requires:
+
 * `--stake.transaction.file` is the input filename of the transaction,
 * `--stake.account.id` is the staking account which pays the transaction fee and
 serves as an escrow.
@@ -140,26 +148,28 @@ Usually, the new balance is seen immediately, but some transactions (for example
 escrow reclaiming) do not take effect until after a debonding period has elapsed,
 so you might need to wait a few blocks for the balances to update.
 
-:::  
+:::
 
 ## Example: Transferring tokens
 
 Token transfer transactions transfer tokens from the signer's account to the
 given destination account. Let's generate a transfer transaction of 1000 tokens
 to account `5ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35`:
+
 ```bash
-$ oasis-node stake account gen_transfer \
-    --genesis.file $GENESIS_FILE_PATH \
-    --entity $ENTITY_DIR_PATH \
-    --stake.transaction.amount 1000 \
-    --stake.transaction.file t.json \
-    --stake.transaction.nonce 1 \
-    --stake.transfer.destination 5ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35 \
-    --stake.transaction.fee.gas 1000 \
-    --stake.transaction.fee.amount 1
+oasis-node stake account gen_transfer \
+  --genesis.file $GENESIS_FILE_PATH \
+  --entity $ENTITY_DIR_PATH \
+  --stake.transaction.amount 1000 \
+  --stake.transaction.file t.json \
+  --stake.transaction.nonce 1 \
+  --stake.transfer.destination 5ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35 \
+  --stake.transaction.fee.gas 1000 \
+  --stake.transaction.fee.amount 1
 ```
 
 We used similar parameters to the ones used for generating the burn transaction:
+
 * `--stake.transaction.amount` is the number of tokens to transfer,
 * `--stake.transaction.file` is the output filename,
 * `--stake.transaction.nonce` is the incremental nonce. In our case, this is the
@@ -170,14 +180,15 @@ account of tokens.
 Let's submit the transaction stored in `t.json`:
 
 ```bash
-$ oasis-node stake account submit \
-    -a $ADDR \
-    --stake.account.id 4ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35 \
-    --stake.transaction.file t.json
+oasis-node stake account submit \
+  -a $ADDR \
+  --stake.account.id 4ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35 \
+  --stake.transaction.file t.json
 ```
 
 Finally let's list all the accounts and their balances by adding `-v` flag for
 increased verbosity:
+
 ```bash
 $ oasis-node stake list -a $ADDR -v
 {"id":"TqUyj5Q+9vZtqu10yw6Zw7HEX3Ywe0JQA9vHyzY47TU=","general_balance":"99999997000","escrow_balance":"100000000000","nonce":2}
@@ -194,18 +205,19 @@ In the third example we will put 3000 tokens to an escrow account
 reclaim them. First, let's generate an escrow transaction and store it to `e.json`:
 
 ```bash
-$ oasis-node stake account gen_escrow \
-    --genesis.file $GENESIS_FILE_PATH \
-    --entity $ENTITY_DIR_PATH \
-    --stake.transaction.amount 3000 \
-    --stake.transaction.file e.json \
-    --stake.transaction.nonce 2 \
-    --stake.escrow.account 6ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35 \
-    --stake.transaction.fee.gas 1000 \
-    --stake.transaction.fee.amount 1
+oasis-node stake account gen_escrow \
+  --genesis.file $GENESIS_FILE_PATH \
+  --entity $ENTITY_DIR_PATH \
+  --stake.transaction.amount 3000 \
+  --stake.transaction.file e.json \
+  --stake.transaction.nonce 2 \
+  --stake.escrow.account 6ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35 \
+  --stake.transaction.fee.gas 1000 \
+  --stake.transaction.fee.amount 1
 ```
 
 Let's submit the escrow transaction and list the accounts:
+
 ```bash
 $ oasis-node stake account submit \
     -a $ADDR \
@@ -221,19 +233,21 @@ Notice 3000 tokens have been deducted from the first account's `general_balance`
 and added to an `escrow_balance` of the third account.
 
 We reclaim 3000 escrowed tokens by generating the reclaim escrow transaction:
+
 ```bash
-$ oasis-node stake account gen_reclaim_escrow \
-    --genesis.file $GENESIS_FILE_PATH \
-    --entity $ENTITY_DIR_PATH \
-    --stake.transaction.amount 3000 \
-    --stake.transaction.file r.json \
-    --stake.transaction.nonce 3 \
-    --stake.escrow.account 6ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35 \
-    --stake.transaction.fee.gas 1000 \
-    --stake.transaction.fee.amount 1
+oasis-node stake account gen_reclaim_escrow \
+  --genesis.file $GENESIS_FILE_PATH \
+  --entity $ENTITY_DIR_PATH \
+  --stake.transaction.amount 3000 \
+  --stake.transaction.file r.json \
+  --stake.transaction.nonce 3 \
+  --stake.escrow.account 6ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35 \
+  --stake.transaction.fee.gas 1000 \
+  --stake.transaction.fee.amount 1
 ```
 
 Let's submit it and in a few moments list the accounts:
+
 ```bash
 $ oasis-node stake account submit \
     -a $ADDR \

--- a/src/operators/staking-competition-rules.md
+++ b/src/operators/staking-competition-rules.md
@@ -136,29 +136,39 @@ these rewards in real time. Examples of these competitions include:
   have something you’d like to build, integrate, or add to the network that’s
   node and testnet related, please apply! We’re excited to see the network
   flourish and want to support those who are as well!
-  
-### Summary of Rewards
-As a whole, the Foundation aims to allot ~1% of total tokens to the various phases of The Quest, across challenge winners, community engagement awards, grants, and more. Top rewards (although there may be more based on the time-based challenges noted above) include:
 
-**Attacks**: 
+### Summary of Rewards
+
+As a whole, the Foundation aims to allot ~1% of total tokens to the various
+phases of The Quest, across challenge winners, community engagement awards,
+grants, and more. Top rewards (although there may be more based on the
+time-based challenges noted above) include:
+
+**Attacks**:
+
 * Best Attack: up to 1,000,000 tokens
 * Top 5 Attacks: up to 500,000 tokens
 
 **Most staked**:
+
 * 1st place: 750,000 tokens
 * Top 5 spots: up to 500,000 tokens
 
 **Most blocks signed**:
+
 * 1st place: 750,000 tokens
 * Top 5 spots: up to 500,000 tokens
 
 **Community**:
+
 * Best team player: up to 100,000 tokens
 * Community content: up to 100,000 tokens
 
 **Participation**:
+
 * All participants (who don't double-sign): 5,000 tokens
-* First 30 entities on the network (who stay through the end with no double-signing): 10,000 tokens
+* First 30 entities on the network (who stay through the end with no
+  double-signing): 10,000 tokens
 
 ## Communication
 


### PR DESCRIPTION
Initially, only for all docs in `src/operators/`, but we should expand this in the future.