### PR TITLE
ci: Re-introduce some markdownlint config changes introduced in e869a09

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -5,20 +5,21 @@
 # Enable all rules.
 default: true
 
-# Line Length.
-#
-# NOTE: The line_length rule is currently not strict enough.
+# NOTE: The line-length rule is currently not strict enough.
 # For more details, see: https://github.com/DavidAnson/markdownlint/issues/237.
-MD013:
+line-length:
   # Allow longer lines for code blocks since account ids are 64 characters long
   # by themselves.
-  code_block_line_length: 99
+  code_block_line_length: 100
 
-# Inline HTML.
-MD033:
+no-inline-html:
   allowed_elements:
     # Allow raw <code> ... </code> elements because we use it as a work-around
     # for lack of Vuepress' support for inline double curly braces that we use
     # for denoting variables.
     # For more details, see: https://github.com/vuejs/vuepress/issues/853.
     - code
+
+# Do not always require language specifiers with fenced code blocks since they
+# are not part of the Markdown spec.
+fenced-code-language: false


### PR DESCRIPTION
Commit e869a09 introduced some markdownlint configuratation changes that
were reverted in commit d6ce3ac. This change brings some of them back.