### PR TITLE
ci: Prevent triggering jobs twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,16 @@
 name: Continuous integration
 
-on: [push, pull_request]
+# Trigger the workflow when:
+on:
+  # A push occurs to one of the matched branches.
+  push:
+    branches:
+      - master
+  # Or when a pull request event occurs for a pull request against one of the
+  # matched branches.
+  pull_request:
+    branches:
+      - master
 
 jobs:
 


### PR DESCRIPTION
Update trigger logic to either trigger the workflow when a push to the `master` branch occurs or when a pull request event for a pull request against the `master` branch occurs.