### PR TITLE
sentry: replace --entity flag with signer flags

### DIFF
--- a/src/operators/sentry-node.md
+++ b/src/operators/sentry-node.md
@@ -182,7 +182,8 @@ export SENTRY1_STATIC_IP=<YOUR_SENTRY1_STATIC_IP>
 export SENTRY2_CONSENSUS_ID=<YOUR_SENTRY2_CONSENSUS_ID_B64>
 export SENTRY2_STATIC_IP=<YOUR_SENTRY2_STATIC_IP>
 oasis-node registry node init \
-  --entity /localhostdir/entity \
+  --signer file \
+  --signer.dir /localhostdir/entity \
   --node.consensus_address $SENTRY1_CONSENSUS_ID@$SENTRY1_STATIC_IP:26656 \
   --node.consensus_address $SENTRY2_CONSENSUS_ID@$SENTRY2_STATIC_IP:26656 \
   --node.is_self_signed \


### PR DESCRIPTION
Seems like this was missed in the flag update pr.

Also checked and there is no other occurrence of `--entity` in the docs.