### PR TITLE
Update Docs for Dashboard Deprecation

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -39,7 +39,6 @@ module.exports = {
     logo: '/logo.svg',
     nav: [
       { text: 'Home', link: 'https://oasislabs.com' },
-      { text: 'Dashboard', link: 'https://dashboard.oasiscloud.io' },
       {
         text: 'Support',
         link:

--- a/src/api-reference/client/developer-gateway.md
+++ b/src/api-reference/client/developer-gateway.md
@@ -13,7 +13,7 @@ new oasis.gateways.Gateway(url, httpHeaders);
 ### Parameters
 
 1. ``url`` - ``String``: The url of the gateway.
-2. `apiToken` - `String`: Api token created by the [dashboard](https://dashboard.oasiscloud.io/login).
+2. `apiToken` - `String`: Your developer token.
 2. ``httpHeaders`` - ``Object``: The http headers to use for authentiication with the gateway.
 For example, `{ headers: new Map([['X-OASIS-INSECURE-AUTH', 'VALUE']]) }`.
 

--- a/src/overview.md
+++ b/src/overview.md
@@ -52,15 +52,7 @@ With our recent runtime change to WASM we also have the ability to support langu
 
 This opens the possibility to support languages like C, C++, Java, and Go. 
 
-If you have a specific need for your use-case, please send us a note at devrel@oasislabs.com to help us prioritize.  
-
-#### How do I debug transactions on the network? 
-
-Use Oasis Explorer: https://dashboard.oasiscloud.io/explorer. 
-
-You can search network logs for wallet address or transaction id or a block address. 
-
-For your deployed service, you can also view Logs tab on the dashboard for recent transactions.
+If you have a specific need for your use-case, please send us a note at devrel@oasislabs.com to help us prioritize.
 
 #### Can I write a confidential smart contract in Solidity?
 

--- a/src/quickstart.md
+++ b/src/quickstart.md
@@ -72,14 +72,7 @@ Tests:       3 passed, 3 total
 
 ## Deploy on Devnet 2.0
 
-1. Login to the [Oasis developer dashboard](https://dashboard.oasiscloud.io) and visit `My Account`.
-2. Make sure you are in a secure location, and then *Click to reveal* your API token in the `Credentials` section of the `Account Info` tab. You must never lose your API token nor share it with anyone!
-3. Give your local toolchain access to deploy services on your behalf by running the following command, which will begin to read your credential from stdin.
-You should then paste your credential in and hit enter.
-   ```
-   oasis config profile.default.credential -
-   ```
-You can now deploy your service to Devnet 2.0, using `oasis deploy`.
+You can deploy your service to Devnet 2.0 using `oasis deploy`.
 When you run that command, with any luck, you'll see something like the following:
 
 ```

--- a/src/tutorials/web3-intro.md
+++ b/src/tutorials/web3-intro.md
@@ -45,7 +45,6 @@ const provider = new HDWalletProvider(MNEMONIC, URL);
 
 **Connecting to Oasis Devnet:** To connect to the Oasis Devnet, use the link `wss://web3.devnet.oasiscloud.io/ws`. 
 You will likely want to connect your own account; do this by providing your mnemonic (if you're using an HD wallet), private key, or array of private keys.
-The [Oasis Dashboard](https://dashboard.oasiscloud.io) accounts are not compatible with Web3. 
 
 To keep your mnemonic or private key secret, instead of including them in your code, you may want to input them at runtime as  environment variables.
 


### PR DESCRIPTION
Removes references to the Dashboard from our documentation. Full info and rationale for Dashboard Deprecation [here](https://docs.google.com/document/d/1QlISqAoL_kZqAT0FTod5APqKHojfvIgbGMPTkkEo5s8/edit#)

(Note: this PR does _not_ correct parts of the documentation that are inaccurate because tools are broken or have changed. It _only_ seeks to remove references to the Dashboard)