### PR TITLE
Fix "Help us improve this page!" links

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -148,6 +148,7 @@ module.exports = {
     ],
     repo: 'oasislabs',
     docsRepo: 'oasislabs/docs',
+    docsDir: 'src',
     docsBranch: 'master',
     editLinks: true,
     editLinkText: 'Help us improve this page!',


### PR DESCRIPTION
As pointed out by @bardovv on community slack, page-editing links ("Help us improve this page!" at the bottom of each page) are broken; see e.g. https://docs.oasis.dev/operators/architecture-overview.html#entities-and-key-management

According to https://vuepress.vuejs.org/theme/default-theme-config.html#git-repository-and-edit-links, this PR should fix that (our docs live in `src/`, rather than the repo root). The change is untested, though.